### PR TITLE
Improve OBIS request validation and error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -252,6 +252,12 @@ def resolve_common_to_scientific(query: str) -> Tuple[str, str]:
     return q, "Unchanged"
 
 # ----------- OBIS INTEGRATION -----------
+
+
+class OBISFetchError(Exception):
+    """Raised when the OBIS service cannot fulfill a request."""
+
+
 def _sanitize_bbox(bbox: Dict[str, Any]) -> Dict[str, float]:
     """Validate and coerce a bounding box dictionary."""
     required = ("lonmin", "lonmax", "latmin", "latmax")
@@ -276,7 +282,72 @@ def _sanitize_bbox(bbox: Dict[str, Any]) -> Dict[str, float]:
     return {"lonmin": lonmin, "lonmax": lonmax, "latmin": latmin, "latmax": latmax}
 
 
+def _bbox_to_wkt(bbox: Dict[str, float]) -> str:
+    return (
+        "POLYGON(("
+        f"{bbox['lonmin']} {bbox['latmin']}, "
+        f"{bbox['lonmax']} {bbox['latmin']}, "
+        f"{bbox['lonmax']} {bbox['latmax']}, "
+        f"{bbox['lonmin']} {bbox['latmax']}, "
+        f"{bbox['lonmin']} {bbox['latmin']}))"
+    )
+
+
+def _request_obis(params: Dict[str, Any], retries: int = 3, timeout: float = 40.0) -> requests.Response:
+    backoff = 1.2
+    last_exception: Optional[Exception] = None
+    for attempt in range(1, retries + 1):
+        try:
+            response = requests.get(OBIS_API_URL, params=params, timeout=timeout)
+        except requests.RequestException as exc:
+            last_exception = exc
+        else:
+            if response.status_code >= 500 and attempt < retries:
+                time.sleep(min(6.0, backoff ** attempt))
+                continue
+            return response
+        time.sleep(min(6.0, backoff ** attempt))
+    if last_exception is not None:
+        raise OBISFetchError(f"OBIS request failed: {last_exception}")
+    raise OBISFetchError("OBIS request failed after repeated server errors")
+
+
 @cache_data(ttl=60 * 30)
+def _fetch_obis_records_cached(species_name: str, size: int, geometry: Optional[str]) -> pd.DataFrame:
+    params = {"scientificname": species_name, "size": size}
+    if geometry:
+        params["geometry"] = geometry
+
+    response = _request_obis(params)
+
+    if response.status_code >= 400:
+        detail = None
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                for key in ("message", "error", "detail"):
+                    if payload.get(key):
+                        detail = str(payload[key])
+                        break
+        except ValueError:
+            pass
+
+        if not detail:
+            detail = response.reason or response.text[:200]
+        raise OBISFetchError(f"OBIS request failed with status {response.status_code}: {detail}")
+
+    try:
+        js = response.json()
+    except ValueError as exc:
+        raise OBISFetchError(f"OBIS response was not valid JSON: {exc}") from exc
+
+    results = js.get("results", []) if isinstance(js, dict) else []
+    if not isinstance(results, list):
+        raise OBISFetchError("OBIS response format was unexpected")
+
+    return pd.DataFrame(results)
+
+
 def fetch_obis_records(
     species_name: str,
     size: int = 200,
@@ -289,55 +360,21 @@ def fetch_obis_records(
     except (TypeError, ValueError):
         return pd.DataFrame(), "Requested record count must be an integer"
 
-    params = {"scientificname": species_name, "size": size_int}
-
+    geometry: Optional[str] = None
     if bbox:
         try:
             bbox_clean = _sanitize_bbox(bbox)
         except ValueError as exc:
             return pd.DataFrame(), f"Invalid bounding box: {exc}"
-        poly = (
-            "POLYGON(("
-            f"{bbox_clean['lonmin']} {bbox_clean['latmin']}, "
-            f"{bbox_clean['lonmax']} {bbox_clean['latmin']}, "
-            f"{bbox_clean['lonmax']} {bbox_clean['latmax']}, "
-            f"{bbox_clean['lonmin']} {bbox_clean['latmax']}, "
-            f"{bbox_clean['lonmin']} {bbox_clean['latmin']}))"
-        )
-        params["geometry"] = poly
+        geometry = _bbox_to_wkt(bbox_clean)
 
     try:
-        r = requests.get(OBIS_API_URL, params=params, timeout=40)
-    except requests.RequestException as exc:
-        return pd.DataFrame(), f"OBIS request failed: {exc}"
+        df = _fetch_obis_records_cached(species_name, size_int, geometry)
+    except OBISFetchError as exc:
+        return pd.DataFrame(), str(exc)
 
-    if r.status_code >= 400:
-        detail = None
-        try:
-            payload = r.json()
-            if isinstance(payload, dict):
-                for key in ("message", "error", "detail"):
-                    if payload.get(key):
-                        detail = str(payload[key])
-                        break
-        except ValueError:
-            # Response body is not JSON – fall back to reason/text
-            pass
+    return df, None
 
-        if not detail:
-            detail = r.reason or r.text[:200]
-        return pd.DataFrame(), f"OBIS request failed with status {r.status_code}: {detail}"
-
-    try:
-        js = r.json()
-    except ValueError as exc:
-        return pd.DataFrame(), f"OBIS response was not valid JSON: {exc}"
-
-    results = js.get("results", []) if isinstance(js, dict) else []
-    if not isinstance(results, list):
-        return pd.DataFrame(), "OBIS response format was unexpected"
-
-    return pd.DataFrame(results), None
 
 def make_plots_from_df(df: pd.DataFrame, species_name: str) -> Dict[str, Any]:
     figs = {}
@@ -473,7 +510,7 @@ def generate_pdf_report(df: pd.DataFrame, species_name: str, summary_text: str, 
     title = f"OBIS Report — {species_name}" if species_name else "OBIS Report"
     story.append(Paragraph(title, styles["ReportTitle"]))
     story.append(Spacer(1, 6))
-    story.append(Paragraph(f"Generated: {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}", styles["Meta"]))
+    story.append(Paragraph(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}", styles["Meta"]))
     story.append(Paragraph(f"Total records: {len(df)}", styles["Meta"]))
     story.append(Spacer(1, 10))
     story.append(Paragraph("AI Summary", styles["Heading"]))
@@ -943,6 +980,7 @@ with st.sidebar:
 
     max_records = st.slider("Max OBIS records", 10, 3000, 500, step=10)
     bbox_enable = st.checkbox("Filter by bounding box", value=False)
+    st.session_state["bbox_enable"] = bbox_enable
     if bbox_enable:
         lon_min = st.number_input("Lon min", value=68.0, step=0.1, format="%.3f")
         lon_max = st.number_input("Lon max", value=96.0, step=0.1, format="%.3f")
@@ -985,7 +1023,7 @@ st.session_state.setdefault("bookmarks", [])
 
 def add_to_history(display, scientific, provenance):
     st.session_state["search_history"].append({
-        "t": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        "t": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
         "q": display, "sci": scientific, "prov": provenance
     })
     if len(st.session_state["search_history"]) > 20:
@@ -1060,7 +1098,7 @@ if df_prev is not None and not df_prev.empty:
             with st.spinner("AI analyzing..."):
                 ans = ask_openrouter([{"role":"system","content":"You are a helpful marine data assistant. Be concise."},
                                       {"role":"user","content":"\n\n".join(parts)}])
-            st.session_state.setdefault("data_ai_history", []).append({"q": ai_q, "a": ans, "time": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")})
+            st.session_state.setdefault("data_ai_history", []).append({"q": ai_q, "a": ans, "time": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")})
             st.session_state["last_summary"] = st.session_state.get("last_summary") or ans
             st.markdown("**AI answer:**"); st.markdown(ans)
 
@@ -1225,7 +1263,7 @@ if submitted and query.strip():
                     with st.spinner("AI analyzing..."):
                         ans = ask_openrouter([{"role":"system","content":"You are a helpful marine data assistant. Be concise."},
                                               {"role":"user","content":"\n\n".join(parts)}])
-                    st.session_state.setdefault("data_ai_history", []).append({"q": ai_q, "a": ans, "time": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")})
+                    st.session_state.setdefault("data_ai_history", []).append({"q": ai_q, "a": ans, "time": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")})
                     st.session_state["last_summary"] = ans
                     st.markdown("**AI answer:**"); st.markdown(ans)
 
@@ -1265,4 +1303,4 @@ with st.expander("Saved searches & bookmarks"):
 # ----------- FOOTER -----------
 st.markdown("---")
 st.markdown("<div class='small muted'>Data: OBIS (api.obis.org) • ERDDAP • Geocoding: Nominatim • LLM: OpenRouter</div>", unsafe_allow_html=True)
-st.markdown("<div class='muted small'>Last updated: " + datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC") + "</div>", unsafe_allow_html=True)
+st.markdown("<div class='muted small'>Last updated: " + datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC") + "</div>", unsafe_allow_html=True)

--- a/app.py
+++ b/app.py
@@ -252,16 +252,76 @@ def resolve_common_to_scientific(query: str) -> Tuple[str, str]:
     return q, "Unchanged"
 
 # ----------- OBIS INTEGRATION -----------
+def _sanitize_bbox(bbox: Dict[str, Any]) -> Dict[str, float]:
+    """Validate and coerce a bounding box dictionary."""
+    required = ("lonmin", "lonmax", "latmin", "latmax")
+    missing = [k for k in required if k not in bbox]
+    if missing:
+        raise ValueError(f"Missing keys: {', '.join(missing)}")
+    try:
+        lonmin = float(bbox["lonmin"])
+        lonmax = float(bbox["lonmax"])
+        latmin = float(bbox["latmin"])
+        latmax = float(bbox["latmax"])
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Bounding box values must be numeric") from exc
+    if lonmin >= lonmax:
+        raise ValueError("Longitude minimum must be less than maximum")
+    if latmin >= latmax:
+        raise ValueError("Latitude minimum must be less than maximum")
+    if not (-180.0 <= lonmin <= 180.0 and -180.0 <= lonmax <= 180.0):
+        raise ValueError("Longitudes must be within -180 to 180")
+    if not (-90.0 <= latmin <= 90.0 and -90.0 <= latmax <= 90.0):
+        raise ValueError("Latitudes must be within -90 to 90")
+    return {"lonmin": lonmin, "lonmax": lonmax, "latmin": latmin, "latmax": latmax}
+
+
 @cache_data(ttl=60 * 30)
-def fetch_obis_records(species_name: str, size: int = 200, bbox: Optional[Dict] = None) -> pd.DataFrame:
-    params = {"scientificname": species_name, "size": int(size)}
-    if bbox and all(k in bbox for k in ("lonmin", "lonmax", "latmin", "latmax")):
-        poly = f"POLYGON(({bbox['lonmin']} {bbox['latmin']}, {bbox['lonmax']} {bbox['latmin']}, {bbox['lonmax']} {bbox['latmax']}, {bbox['lonmin']} {bbox['latmax']}, {bbox['lonmin']} {bbox['latmin']}))"
+def fetch_obis_records(
+    species_name: str,
+    size: int = 200,
+    bbox: Optional[Dict[str, Any]] = None,
+) -> Tuple[pd.DataFrame, Optional[str]]:
+    """Fetch OBIS occurrences, returning (dataframe, error_message)."""
+
+    try:
+        size_int = max(1, int(size))
+    except (TypeError, ValueError):
+        return pd.DataFrame(), "Requested record count must be an integer"
+
+    params = {"scientificname": species_name, "size": size_int}
+
+    if bbox:
+        try:
+            bbox_clean = _sanitize_bbox(bbox)
+        except ValueError as exc:
+            return pd.DataFrame(), f"Invalid bounding box: {exc}"
+        poly = (
+            "POLYGON(("
+            f"{bbox_clean['lonmin']} {bbox_clean['latmin']}, "
+            f"{bbox_clean['lonmax']} {bbox_clean['latmin']}, "
+            f"{bbox_clean['lonmax']} {bbox_clean['latmax']}, "
+            f"{bbox_clean['lonmin']} {bbox_clean['latmax']}, "
+            f"{bbox_clean['lonmin']} {bbox_clean['latmin']}))"
+        )
         params["geometry"] = poly
-    r = requests.get(OBIS_API_URL, params=params, timeout=40)
-    r.raise_for_status()
-    js = r.json()
-    return pd.DataFrame(js.get("results", []))
+
+    try:
+        r = requests.get(OBIS_API_URL, params=params, timeout=40)
+        r.raise_for_status()
+    except requests.RequestException as exc:
+        return pd.DataFrame(), f"OBIS request failed: {exc}"
+
+    try:
+        js = r.json()
+    except ValueError as exc:
+        return pd.DataFrame(), f"OBIS response was not valid JSON: {exc}"
+
+    results = js.get("results", []) if isinstance(js, dict) else []
+    if not isinstance(results, list):
+        return pd.DataFrame(), "OBIS response format was unexpected"
+
+    return pd.DataFrame(results), None
 
 def make_plots_from_df(df: pd.DataFrame, species_name: str) -> Dict[str, Any]:
     figs = {}
@@ -1038,18 +1098,38 @@ if submitted and query.strip():
         if st.button(f"⭐ Bookmark {sci}", key=f"bm_{sci}"):
             bookmark_current(sci); st.success("Bookmarked!")
 
-        with st.spinner("Fetching OBIS records..."):
-            bbox = None
-            if st.session_state.get("bbox_enable", bbox_enable):
-                bbox = {"lonmin": lon_min, "lonmax": lon_max, "latmin": lat_min, "latmax": lat_max}
-            df = fetch_obis_records(sci, size=max_records, bbox=bbox)
+        df = pd.DataFrame()
+        fetch_error: Optional[str] = None
 
-        # Date filter
-        if not df.empty and "eventDate" in df.columns:
+        if start_date and end_date and start_date > end_date:
+            fetch_error = "Start date must be on or before end date."
+        else:
+            bbox_params = None
+            if st.session_state.get("bbox_enable", bbox_enable):
+                try:
+                    bbox_params = _sanitize_bbox({
+                        "lonmin": lon_min,
+                        "lonmax": lon_max,
+                        "latmin": lat_min,
+                        "latmax": lat_max,
+                    })
+                except ValueError as exc:
+                    fetch_error = f"Bounding box error: {exc}"
+
+            if fetch_error is None:
+                with st.spinner("Fetching OBIS records..."):
+                    df, fetch_error = fetch_obis_records(sci, size=max_records, bbox=bbox_params)
+
+        if fetch_error:
+            left.error(fetch_error)
+
+        if not fetch_error and not df.empty and "eventDate" in df.columns:
             try:
                 df["eventDate"] = pd.to_datetime(df["eventDate"], errors="coerce")
-                if start_date: df = df[df["eventDate"] >= pd.to_datetime(start_date)]
-                if end_date: df = df[df["eventDate"] <= pd.to_datetime(end_date)]
+                if start_date:
+                    df = df[df["eventDate"] >= pd.to_datetime(start_date)]
+                if end_date:
+                    df = df[df["eventDate"] <= pd.to_datetime(end_date)]
             except Exception:
                 pass
 

--- a/app.py
+++ b/app.py
@@ -308,9 +308,25 @@ def fetch_obis_records(
 
     try:
         r = requests.get(OBIS_API_URL, params=params, timeout=40)
-        r.raise_for_status()
     except requests.RequestException as exc:
         return pd.DataFrame(), f"OBIS request failed: {exc}"
+
+    if r.status_code >= 400:
+        detail = None
+        try:
+            payload = r.json()
+            if isinstance(payload, dict):
+                for key in ("message", "error", "detail"):
+                    if payload.get(key):
+                        detail = str(payload[key])
+                        break
+        except ValueError:
+            # Response body is not JSON – fall back to reason/text
+            pass
+
+        if not detail:
+            detail = r.reason or r.text[:200]
+        return pd.DataFrame(), f"OBIS request failed with status {r.status_code}: {detail}"
 
     try:
         js = r.json()


### PR DESCRIPTION
## Summary
- add validation helper to sanitize user-provided bounding boxes before issuing OBIS requests
- harden OBIS fetching against invalid inputs and network/response issues while surfacing errors in the UI

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68d78531003c83248140eb3ef8592809